### PR TITLE
Add browserify to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "spin.js": "^2.3.2"
   },
   "devDependencies": {
+    "browserify": "^12.0.1",
     "chai": "^3.4.0",
     "chai-dom": "^1.4.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
## What does this PR do?

`gulp test:unit` doesn't run after all the node modules are installed, it looks like `package.json` is missing browserify.
## How to test this PR:
- Delete `node_modules` folder
- Run `npm install`
- run `gulp test:unit`
- See if tests pass
