### PR TITLE
Print out error message if there's an error when running build:script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,7 @@ gulp.task('build:script', function(){
     .pipe(through2.obj(function(file, enc, next){
       browserify(file.path)
         .bundle(function(err, res){
+            if(err) { console.log(err.message); }
             file.contents = res;
             next(null, file);
         });


### PR DESCRIPTION
## What does this PR do?

This adds a `console.log` line to to the `build:script` task to make sure an error message is printed out if there's a problem when running that task. This change makes debugging easier.