### PR TITLE
Use data index 1 timeframe if index 2 does not exist

### DIFF
--- a/lib/libraries/index.js
+++ b/lib/libraries/index.js
@@ -154,7 +154,7 @@ function defineC3(){
             options.axis.x = options.axis.x || {};
             options.axis.x.type = 'timeseries';
             options.axis.x.tick = options.axis.x.tick || {
-              format: this.dateFormat() || c3DefaultDateFormat(this.data()[1][0], this.data()[2][0]),
+              format: this.dateFormat() || c3DefaultDateFormat(this.data()[1][0], this.data()[2] ? this.data()[2][0] : this.data()[1][0]),
               culling: { max: 5 }
             };
 


### PR DESCRIPTION
## What does this PR do?
It fixes a bug where a query response with an absolute timeframe that starts and ends on the same day breaks Dataviz. `this.data()[2]` does not exist under these timeframe circumstances, so we should just use the timeframe from `this.data()[1]`.