### PR TITLE
prettyNumber support above quadrillion

### DIFF
--- a/lib/utils/pretty-number.js
+++ b/lib/utils/pretty-number.js
@@ -11,6 +11,10 @@ function prettyNumber(input) {
     return String(input);
   }
 
+  if (String(input).length >= 16) {
+    return sciNo;
+  }
+
   if (input >= 1 || input <= -1) {
     if (input < 0){
       //Pull off the negative side and stash that.

--- a/lib/utils/pretty-number.js
+++ b/lib/utils/pretty-number.js
@@ -11,7 +11,7 @@ function prettyNumber(input) {
     return String(input);
   }
 
-  if (String(input).length >= 16) {
+  if (Math.abs(input) >= 1000000000000000) {
     return sciNo;
   }
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -5,3 +5,4 @@ require('./dataviz/dataviz-spec');
 require('./dataviz/dataviz-data-spec');
 require('./dataviz/dataviz-browser-spec');
 require('./dataset/dataset-spec');
+require('./utils/utils-spec');

--- a/test/unit/utils/utils-spec.js
+++ b/test/unit/utils/utils-spec.js
@@ -13,7 +13,7 @@ describe('Utils', function(){
       expect(prettyNumber(1800000000000000000000)).to.be.a('string');
     });
 
-    it ('should correctly format ints and floats between -1 and 1', function() {
+    it ('should correctly format ints and floats between -1 and 1', function(){
       expect(prettyNumber(-1)).to.eql('-1');
       expect(prettyNumber(-1.0)).to.eql('-1');
       expect(prettyNumber(-1.00)).to.eql('-1');

--- a/test/unit/utils/utils-spec.js
+++ b/test/unit/utils/utils-spec.js
@@ -58,12 +58,20 @@ describe('Utils', function(){
       expect(prettyNumber(-100000000000000)).to.eql('-100T');
     });
 
-    it ('should use exponential notation when called with integers greater than 100T', function(){
+    it ('should use exponential notation when called with integers greater than or equal to quadrillion', function(){
       expect(prettyNumber(1000000000000000)).to.eql('1.00e+15');
       expect(prettyNumber(100000000000000000000)).to.eql('1.00e+20');
       expect(prettyNumber(10052361296322342964777)).to.eql('1.01e+22');
       expect(prettyNumber(10000000000000000000099999)).to.eql('1.00e+25');
       expect(prettyNumber(18642864286428642864286428)).to.eql('1.86e+25');
+    });
+
+    it ('should use exponential notation when called with integers less than or equal to negative quadrillion', function(){
+      expect(prettyNumber(-1000000000000000)).to.eql('-1.00e+15');
+      expect(prettyNumber(-100000000000000000000)).to.eql('-1.00e+20');
+      expect(prettyNumber(-10052361296322342964777)).to.eql('-1.01e+22');
+      expect(prettyNumber(-10000000000000000000099999)).to.eql('-1.00e+25');
+      expect(prettyNumber(-18642864286428642864286428)).to.eql('-1.86e+25');
     });
 
     it ('should have three significant digits in formatted number', function(){

--- a/test/unit/utils/utils-spec.js
+++ b/test/unit/utils/utils-spec.js
@@ -55,13 +55,14 @@ describe('Utils', function(){
       expect(prettyNumber(-100000000000)).to.eql('-100B');
       expect(prettyNumber(-1000000000000)).to.eql('-1T');
       expect(prettyNumber(-10000000000000)).to.eql('-10T');
-      expect(prettyNumber(-100000000000000)).to.eql('-1.00e+14');
+      expect(prettyNumber(-100000000000000)).to.eql('-100T');
     });
 
     it ('should use exponential notation when called with integers greater than 100T', function(){
       expect(prettyNumber(1000000000000000)).to.eql('1.00e+15');
       expect(prettyNumber(100000000000000000000)).to.eql('1.00e+20');
       expect(prettyNumber(10052361296322342964777)).to.eql('1.01e+22');
+      expect(prettyNumber(10000000000000000000099999)).to.eql('1.00e+25');
       expect(prettyNumber(18642864286428642864286428)).to.eql('1.86e+25');
     });
 

--- a/test/unit/utils/utils-spec.js
+++ b/test/unit/utils/utils-spec.js
@@ -6,17 +6,26 @@ describe('Utils', function(){
   describe('prettyNumber', function(){
 
     it ('should return a string', function(){
+      expect(prettyNumber(-45.009)).to.be.a('string');
+      expect(prettyNumber(.000005)).to.be.a('string');
+      expect(prettyNumber(0)).to.be.a('string');
       expect(prettyNumber(123456)).to.be.a('string');
+      expect(prettyNumber(1800000000000000000000)).to.be.a('string');
     });
 
     it ('should correctly format ints and floats between -1 and 1', function() {
-      expect(prettyNumber(-1)).to.be.a('string').and.to.eql('-1');
-      expect(prettyNumber(-1.0)).to.be.a('string').and.to.eql('-1');
-      expect(prettyNumber(-1.00)).to.be.a('string').and.to.eql('-1');
-      expect(prettyNumber(0)).to.be.a('string').and.to.eql('0');
-      expect(prettyNumber(1)).to.be.a('string').and.to.eql('1');
-      expect(prettyNumber(1.0)).to.be.a('string').and.to.eql('1');
-      expect(prettyNumber(1.00)).to.be.a('string').and.to.eql('1');
+      expect(prettyNumber(-1)).to.eql('-1');
+      expect(prettyNumber(-1.0)).to.eql('-1');
+      expect(prettyNumber(-1.00)).to.eql('-1');
+      expect(prettyNumber(-.00000000000000005)).to.eql('-5.00e-17');
+      expect(prettyNumber(-.0070304020)).to.eql('-0.00703');
+      expect(prettyNumber(0)).to.eql('0');
+      expect(prettyNumber(.0000000000001)).to.eql('1.00e-13');
+      expect(prettyNumber(.0000560002)).to.eql('0.0000560');
+      expect(prettyNumber(.098768)).to.eql('0.0988');
+      expect(prettyNumber(1)).to.eql('1');
+      expect(prettyNumber(1.0)).to.eql('1');
+      expect(prettyNumber(1.00)).to.eql('1');
     });
 
     it ('should use correct suffix when called with ints between one thousand and one hundred trillion', function(){
@@ -32,6 +41,21 @@ describe('Utils', function(){
       expect(prettyNumber(1000000000000)).to.eql('1T');
       expect(prettyNumber(10000000000000)).to.eql('10T');
       expect(prettyNumber(100000000000000)).to.eql('100T');
+    });
+
+    it ('should use correct suffix when called with negative ints', function(){
+      expect(prettyNumber(-1000)).to.eql('-1k');
+      expect(prettyNumber(-10000)).to.eql('-10k');
+      expect(prettyNumber(-100000)).to.eql('-100k');
+      expect(prettyNumber(-1000000)).to.eql('-1M');
+      expect(prettyNumber(-10000000)).to.eql('-10M');
+      expect(prettyNumber(-100000000)).to.eql('-100M');
+      expect(prettyNumber(-1000000000)).to.eql('-1B');
+      expect(prettyNumber(-10000000000)).to.eql('-10B');
+      expect(prettyNumber(-100000000000)).to.eql('-100B');
+      expect(prettyNumber(-1000000000000)).to.eql('-1T');
+      expect(prettyNumber(-10000000000000)).to.eql('-10T');
+      expect(prettyNumber(-100000000000000)).to.eql('-1.00e+14');
     });
 
     it ('should use exponential notation when called with integers greater than 100T', function(){

--- a/test/unit/utils/utils-spec.js
+++ b/test/unit/utils/utils-spec.js
@@ -1,0 +1,54 @@
+var expect = require('chai').expect;
+var prettyNumber = require('../../../lib/utils/pretty-number');
+
+describe('Utils', function(){
+
+  describe('prettyNumber', function(){
+
+    it ('should return a string', function(){
+      expect(prettyNumber(123456)).to.be.a('string');
+    });
+
+    it ('should correctly format ints and floats between -1 and 1', function() {
+      expect(prettyNumber(-1)).to.be.a('string').and.to.eql('-1');
+      expect(prettyNumber(-1.0)).to.be.a('string').and.to.eql('-1');
+      expect(prettyNumber(-1.00)).to.be.a('string').and.to.eql('-1');
+      expect(prettyNumber(0)).to.be.a('string').and.to.eql('0');
+      expect(prettyNumber(1)).to.be.a('string').and.to.eql('1');
+      expect(prettyNumber(1.0)).to.be.a('string').and.to.eql('1');
+      expect(prettyNumber(1.00)).to.be.a('string').and.to.eql('1');
+    });
+
+    it ('should use correct suffix when called with ints between one thousand and one hundred trillion', function(){
+      expect(prettyNumber(1000)).to.eql('1000');
+      expect(prettyNumber(10000)).to.eql('10k');
+      expect(prettyNumber(100000)).to.eql('100k');
+      expect(prettyNumber(1000000)).to.eql('1M');
+      expect(prettyNumber(10000000)).to.eql('10M');
+      expect(prettyNumber(100000000)).to.eql('100M');
+      expect(prettyNumber(1000000000)).to.eql('1B');
+      expect(prettyNumber(10000000000)).to.eql('10B');
+      expect(prettyNumber(100000000000)).to.eql('100B');
+      expect(prettyNumber(1000000000000)).to.eql('1T');
+      expect(prettyNumber(10000000000000)).to.eql('10T');
+      expect(prettyNumber(100000000000000)).to.eql('100T');
+    });
+
+    it ('should use exponential notation when called with integers greater than 100T', function(){
+      expect(prettyNumber(1000000000000000)).to.eql('1.00e+15');
+      expect(prettyNumber(100000000000000000000)).to.eql('1.00e+20');
+      expect(prettyNumber(10052361296322342964777)).to.eql('1.01e+22');
+      expect(prettyNumber(18642864286428642864286428)).to.eql('1.86e+25');
+    });
+
+    it ('should have three significant digits in formatted number', function(){
+      expect(prettyNumber(1230)).to.eql('1230');
+      expect(prettyNumber(12300)).to.eql('12.3k');
+      expect(prettyNumber(12340)).to.eql('12.3k');
+      expect(prettyNumber(123450)).to.eql('123k');
+      expect(prettyNumber(15.92)).to.eql('15.9');
+    });
+
+  });
+  
+});


### PR DESCRIPTION
## What does this PR do? How does it affect users?

This PR adds formatting support for numbers greater than or equal to a quadrillion (10^15). It also handles numbers less than or equal to -10^15.

This resolves an issue with the `prettyNumber` function returning `undefined` when 
it runs out of suffixes for large numbers. Now these numbers will be displayed in exponential/scientific notation.

### Before

A query returning `{"result": 4540855509263536 }` would display as:

![screen shot 2017-01-03 at 1 02 39 pm](https://cloud.githubusercontent.com/assets/6183404/21622964/f9c8036c-d1b4-11e6-8649-36a339c5cb87.png)

### After 

A query returning `{"result": 4540855509263536 }` will display as:

![screen shot 2017-01-03 at 1 05 57 pm](https://cloud.githubusercontent.com/assets/6183404/21623048/6d36adda-d1b5-11e6-9b06-78cf3d73a987.png)

## How is this tested?

Unit tests for this change are located in `utils-spec.js`. I also added some additional unit test coverage for the `prettyNumber` function in that file.