### PR TITLE
render#domReady: this => self

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -343,7 +343,7 @@
       }
       else {
         if (typeof Dataviz.libraries[library][type] === 'undefined') {
-          this.message('Incorrect chart type');
+          self.message('Incorrect chart type');
           throw 'Incorrect chart type';
           return;
         }


### PR DESCRIPTION
Within the context of the domReady() function, `this` no longer refers to the `Dataviz` instance--need to use `self` instead.

Thanks!