### PR TITLE
Fix that ellipsis is not working in the legend

### DIFF
--- a/lib/style/keen-dataviz.css
+++ b/lib/style/keen-dataviz.css
@@ -466,10 +466,7 @@
   .legend-item{
     display: flex;
     cursor: pointer;
-    overflow: hidden;
     padding: 0.2em;
-    white-space: nowrap;
-    text-overflow: ellipsis;
     font-size: 0.8em;
     > * {
       vertical-align: middle;
@@ -484,6 +481,10 @@
     }
     &-text{
       pointer-events: none;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      text-align: left;
     }
   }
 


### PR DESCRIPTION
<!-- 
- If certain testing steps are not relevant, specify that in the PR. 
- If additional checks are needed, add 'em! 
- Please run through all testing steps in the below checklist before asking for a review. 
-->

## What does this PR do? How does it affect users?
Ellipsis stuff (overflow, text-overflow and white-space) are moved from legend-item to legend-item-text.
I find that ellipsis is not working in the legend. The reason may be that text wrapping will not work for a flexbox.

## Related tickets?

## How should this be tested?
In the demo page, text in the legend of Multi Spine Chart will be wrapped using '...'.

Step through the code line by line. Things to keep in mind as you review:
 - Are there any edge cases not covered by this code?
 - Does this code follow conventions (naming, formatting, modularization, etc) where applicable?

Fetch the branch and/or deploy to staging to test the following:

- [x] Does the code compile without warnings (check shell, console)?
- [x] Do all tests pass?
- [x] Does the UI, pixel by pixel, look exactly as expected (check various screen sizes, including mobile)?
- [x] If the feature makes requests from the browser, inspect them in the Web Inspector. Do they look as expected (parameters, headers, etc)?
- [x] If the feature sends data to Keen, is the data visible in the project if you run an extraction (include link to collection/query)?
- [x] If the feature saves data to a database, can you confirm the data is indeed created in the database?
