### PR TITLE
Fix `npm install`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19351,14 +19351,14 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.2.tgz",
-      "integrity": "sha512-RRTAkzsGiOP8PwGwLfd/H0NbotLXyS5zxg4EbuQ2K3aNqgUOVbOzBKKvTXzUsKiwVs+pBpBtqBYHj6PS6JVXDQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "dev": true,
       "requires": {
-        "http-parser-js": ">= 0.4.0, < 0.4.11",
-        "safe-buffer": ">= 5.1.0",
-        "websocket-extensions": ">= 0.1.1"
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {


### PR DESCRIPTION
Previously, a fresh install fails due to websocket-driver@0.7.2 being
pulled. See:

https://github.com/faye/websocket-driver-node/blob/master/CHANGELOG.md

Lots of issues like ex.
https://github.com/faye/websocket-driver-node/issues/34

This bumps websocket-driver to 0.7.3 so `npm install` succeeds.

<!-- 
- If certain testing steps are not relevant, specify that in the PR. 
- If additional checks are needed, add 'em! 
- Please run through all testing steps in the below checklist before asking for a review. 
-->

## What does this PR do? How does it affect users?

Fixes `npm install`

## Related tickets?

Nope

## How should this be tested?

Start a fresh project or `rm -rf node_modules`, then `npm install`.

Step through the code line by line. Things to keep in mind as you review:

 - Are there any edge cases not covered by this code?

N/A

 - Does this code follow conventions (naming, formatting, modularization, etc) where applicable?

N/A

Fetch the branch and/or deploy to staging to test the following:

- [✓] Does the code compile without warnings (check shell, console)?
- [✓] Do all tests pass?
- [N/A] Does the UI, pixel by pixel, look exactly as expected (check various screen sizes, including mobile)?
- [N/A] If the feature makes requests from the browser, inspect them in the Web Inspector. Do they look as expected (parameters, headers, etc)?
- [N/A] If the feature sends data to Keen, is the data visible in the project if you run an extraction (include link to collection/query)?
- [N/A] If the feature saves data to a database, can you confirm the data is indeed created in the database?
