### PR TITLE
Check if c3 artifact exists before load

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -773,7 +773,7 @@ Dataviz.prototype.render = function(results = undefined){
               visibilityChange = "webkitvisibilitychange";
             }
             const handleVisibilityChange = () => {
-              if(!document[hidden] && typeof datavizInstance.view._artifacts.c3 !== 'undefined') {
+              if(!document[hidden] && datavizInstance.view._artifacts.c3) {
                 datavizInstance.view._artifacts.c3.load(datavizInstance.dataset.matrix);
               }
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ export const Dataviz = function (options = {}) {
       executionMetadata: true,
     },
     utils: {
-      clickToCopyToClipboard: true, 
+      clickToCopyToClipboard: true,
     },
 
     indexBy: 'timeframe.start',
@@ -294,7 +294,7 @@ export const Dataviz = function (options = {}) {
   }
 
 };
-  
+
 
 Dataviz.libraries = { default: {} };
 if (typeof window !== 'undefined') {
@@ -773,7 +773,7 @@ Dataviz.prototype.render = function(results = undefined){
               visibilityChange = "webkitvisibilitychange";
             }
             const handleVisibilityChange = () => {
-              if(!document[hidden]) {
+              if(!document[hidden] && typeof datavizInstance.view._artifacts.c3 !== 'undefined') {
                 datavizInstance.view._artifacts.c3.load(datavizInstance.dataset.matrix);
               }
             }


### PR DESCRIPTION
## What does this PR do? How does it affect users?

When a chart is hidden at first, there's a callback which loads the dataset matrix in it. This PR adds a condition to check if `datavizInstance.view._artifacts.c3` exists before calling the `load` function on it.

## Related tickets?

I didn't create a ticket for this, but I had a problem with using this library and Keen Analysis.

Loading the results from a Keen Analysis query in a closed tab and then accessing it showed an error in the inspector : `Uncaught TypeError: Cannot read property 'load' of undefined.`

## How should this be tested?

Load a page containing a chart with results loaded from a Keen Analysis query in a closed tab, then access it to see the chart.

Fetch the branch and/or deploy to staging to test the following:

- [ ] Does the code compile without warnings (check shell, console)?
- [ ] Do all tests pass?
- [ ] Does the UI, pixel by pixel, look exactly as expected (check various screen sizes, including mobile)?
- [ ] If the feature makes requests from the browser, inspect them in the Web Inspector. Do they look as expected (parameters, headers, etc)?
- [ ] If the feature sends data to Keen, is the data visible in the project if you run an extraction (include link to collection/query)?
- [ ] If the feature saves data to a database, can you confirm the data is indeed created in the database?
